### PR TITLE
Do not serialize string before enqueueing it

### DIFF
--- a/src/StupidEnqueueuer.cs
+++ b/src/StupidEnqueueuer.cs
@@ -30,7 +30,7 @@ namespace laget.azure_enqueueuer
             var queue = _client.GetQueueReference(queueName);
             queue.CreateIfNotExists();
 
-            var message = new CloudQueueMessage(JsonConvert.SerializeObject(msg));
+            var message = new CloudQueueMessage(msg);
             queue.AddMessage(message);
         }
     }


### PR DESCRIPTION
When using this with dynamic objects, the object will be serialized to JSON twice, this causes the queued string to be invalid JSON.

If i call  ```stupidEnqueueuer.Enqueue("dummy-queue", new { name = "Robin" });``` the resulting string will look like this: ```"{\"name\":\"Robin\"}"``` instead of the expected: ```{"name":"Robin"}```

This is because the overload accepting the dynamic object will serialize the dynamic object before passing it to the method accepting the string which also will serialize the incoming string.